### PR TITLE
migrate logic of score from BToken to Avatar

### DIFF
--- a/contracts/bprotocol/Registry.sol
+++ b/contracts/bprotocol/Registry.sol
@@ -16,6 +16,7 @@ contract Registry {
     // BProtocol Contracts
     address public pool;
     address public bComptroller;
+    address public score;
 
     // User => Avatar
     mapping (address => address) public u2a;
@@ -31,7 +32,8 @@ contract Registry {
         address _cEther,
         address _priceOracle,
         address _pool,
-        address _bComptroller
+        address _bComptroller,
+        address _score
     )
         public
     {
@@ -41,6 +43,7 @@ contract Registry {
         priceOracle = _priceOracle;
         pool = _pool;
         bComptroller = _bComptroller;
+        score = _score;
     }
 
     function newAvatar() external returns (address) {
@@ -84,7 +87,7 @@ contract Registry {
      * @return Returns the address of the newly deployed Avatar contract
      */
     function _deployNewAvatar(address user) internal returns (address) {
-        return address(new Avatar(user, pool, bComptroller, comptroller, comp, cEther));
+        return address(new Avatar(user, pool, bComptroller, comptroller, comp, cEther, address(this)));
     }
 
     function isAvatarExist(address avatar) public view returns (bool) {

--- a/contracts/bprotocol/avatar/AbsCToken.sol
+++ b/contracts/bprotocol/avatar/AbsCToken.sol
@@ -6,6 +6,7 @@ import "@nomiclabs/buidler/console.sol";
 import { ICToken } from "../interfaces/CTokenInterfaces.sol";
 import { ICEther } from "../interfaces/CTokenInterfaces.sol";
 import { ICErc20 } from "../interfaces/CTokenInterfaces.sol";
+import { IScore } from "../interfaces/IScore.sol";
 
 import { Cushion } from "./Cushion.sol";
 
@@ -142,8 +143,9 @@ contract AbsCToken is Cushion {
         uint256 seizedCTokens = _doLiquidateBorrow(debtCToken, underlyingAmtToLiquidate, collCToken);
         // Convert seizedCToken to underlyingTokens
         uint256 underlyingSeizedTokens = _toUnderlying(debtCToken, seizedCTokens);
-        _score().updateCollScore(avatarOwner, address(debtCToken), -toInt256(underlyingSeizedTokens));
-        _score().updateDebtScore(avatarOwner, address(collCToken), -toInt256(underlyingAmtToLiquidate));
+        IScore score = _score();
+        score.updateCollScore(avatarOwner, address(debtCToken), -toInt256(underlyingSeizedTokens));
+        score.updateDebtScore(avatarOwner, address(collCToken), -toInt256(underlyingAmtToLiquidate));
         return 0;
     }
 

--- a/contracts/bprotocol/avatar/Avatar.sol
+++ b/contracts/bprotocol/avatar/Avatar.sol
@@ -22,6 +22,7 @@ contract Avatar is AbsComptroller, AbsCToken {
      * @param _comptroller Compound finance Comptroller contract address
      * @param _comp Compound finance COMP token contract address
      * @param _cETH cETH contract address
+     * @param _registry Registry contract address
      */
     constructor(
         address _avatarOwner,
@@ -29,7 +30,8 @@ contract Avatar is AbsComptroller, AbsCToken {
         address _bComptroller,
         address _comptroller,
         address _comp,
-        address _cETH
+        address _cETH,
+        address _registry
     )
         public
         AvatarBase(
@@ -38,7 +40,8 @@ contract Avatar is AbsComptroller, AbsCToken {
             _bComptroller,
             _comptroller,
             _comp,
-            _cETH
+            _cETH,
+            _registry
         )
     {
     }

--- a/contracts/bprotocol/avatar/Avatar.sol
+++ b/contracts/bprotocol/avatar/Avatar.sol
@@ -16,7 +16,7 @@ contract Avatar is AbsComptroller, AbsCToken {
 
     /**
      * @dev Constructor
-     * @param _owner Owner of the Avatar contract
+     * @param _avatarOwner Owner of the Avatar contract
      * @param _pool Pool contract address
      * @param _bComptroller BComptroller contract address
      * @param _comptroller Compound finance Comptroller contract address
@@ -24,7 +24,7 @@ contract Avatar is AbsComptroller, AbsCToken {
      * @param _cETH cETH contract address
      */
     constructor(
-        address _owner,
+        address _avatarOwner,
         address _pool,
         address _bComptroller,
         address _comptroller,
@@ -33,7 +33,7 @@ contract Avatar is AbsComptroller, AbsCToken {
     )
         public
         AvatarBase(
-            _owner,
+            _avatarOwner,
             _pool,
             _bComptroller,
             _comptroller,
@@ -47,9 +47,9 @@ contract Avatar is AbsComptroller, AbsCToken {
     /**
      * @dev Mint cETH using ETH and enter market on Compound
      */
-    function mint(ICEther cEther) public payable {
-        super.mint(cEther);
-        require(_enterMarket(address(cEther)) == 0, "enterMarket-failed");
+    function mint() public payable {
+        super.mint();
+        require(_enterMarket(address(cETH)) == 0, "enterMarket-failed");
     }
 
     //override

--- a/contracts/bprotocol/avatar/AvatarBase.sol
+++ b/contracts/bprotocol/avatar/AvatarBase.sol
@@ -8,6 +8,7 @@ import { ICToken } from "../interfaces/CTokenInterfaces.sol";
 import { IComptroller } from "../interfaces/IComptroller.sol";
 import { IBComptroller } from "../interfaces/IBComptroller.sol";
 import { IRegistry } from "../interfaces/IRegistry.sol";
+import { IScore } from "../interfaces/IScore.sol";
 
 import { Exponential } from "../lib/Exponential.sol";
 
@@ -59,6 +60,7 @@ contract AvatarBase is Exponential {
      * @param _comptroller Compound finance Comptroller contract address
      * @param _comp Compound finance COMP token contract address
      * @param _cETH cETH contract address
+     * @param _registry Registry contract address
      */
     constructor(
         address _avatarOwner,
@@ -66,7 +68,8 @@ contract AvatarBase is Exponential {
         address _bComptroller,
         address _comptroller,
         address _comp,
-        address _cETH
+        address _cETH,
+        address _registry
     )
         internal
     {
@@ -78,6 +81,7 @@ contract AvatarBase is Exponential {
         comptroller = IComptroller(_comptroller);
         comp = IERC20(_comp);
         cETH = ICEther(_cETH);
+        registry = IRegistry(_registry);
     }
 
     /**
@@ -109,6 +113,16 @@ contract AvatarBase is Exponential {
 
     function _isCEther(ICToken cToken) internal view returns (bool) {
         return address(cToken) == address(cETH);
+    }
+
+    function _score() internal view returns (IScore) {
+        return IScore(registry.score());
+    }
+
+    function toInt256(uint256 value) internal pure returns (int256) {
+        int256 result = int256(value);
+        require(result >= 0, "Cast from uint to int failed");
+        return result;
     }
 
     function isPartiallyLiquidated() public view returns (bool) {

--- a/contracts/bprotocol/avatar/AvatarBase.sol
+++ b/contracts/bprotocol/avatar/AvatarBase.sol
@@ -7,6 +7,7 @@ import { ICEther } from "../interfaces/CTokenInterfaces.sol";
 import { ICToken } from "../interfaces/CTokenInterfaces.sol";
 import { IComptroller } from "../interfaces/IComptroller.sol";
 import { IBComptroller } from "../interfaces/IBComptroller.sol";
+import { IRegistry } from "../interfaces/IRegistry.sol";
 
 import { Exponential } from "../lib/Exponential.sol";
 
@@ -17,8 +18,9 @@ contract AvatarBase is Exponential {
     using SafeERC20 for IERC20;
 
     // Owner of the Avatar
-    address payable public owner;
+    address payable public avatarOwner;
     address payable public pool;
+    IRegistry public registry;
     IBComptroller public bComptroller;
     IComptroller public comptroller;
     IERC20 public comp;
@@ -51,6 +53,7 @@ contract AvatarBase is Exponential {
 
     /**
      * @dev Constructor
+     * @param _avatarOwner Owner of this avatar instance
      * @param _pool Pool contract address
      * @param _bComptroller BComptroller contract address
      * @param _comptroller Compound finance Comptroller contract address
@@ -58,7 +61,7 @@ contract AvatarBase is Exponential {
      * @param _cETH cETH contract address
      */
     constructor(
-        address _owner,
+        address _avatarOwner,
         address _pool,
         address _bComptroller,
         address _comptroller,
@@ -67,9 +70,9 @@ contract AvatarBase is Exponential {
     )
         internal
     {
-        // Converting `_owner` address to payable address here, so that we don't need to pass
+        // Converting `_avatarOwner` address to payable address here, so that we don't need to pass
         // `address payable` in inheritance hierarchy
-        owner = address(uint160(_owner));
+        avatarOwner = address(uint160(_avatarOwner));
         pool = address(uint160(_pool));
         bComptroller = IBComptroller(_bComptroller);
         comptroller = IComptroller(_comptroller);

--- a/contracts/bprotocol/btoken/BErc20.sol
+++ b/contracts/bprotocol/btoken/BErc20.sol
@@ -28,7 +28,6 @@ contract BErc20 is BToken {
         underlying.safeTransferFrom(msg.sender, address(_avatar), mintAmount);
         uint256 result = _avatar.mint(cToken, mintAmount);
         require(result == 0, "BErc20: mint-failed");
-        updateCollScore(msg.sender, cToken, toInt256(mintAmount));
         return result;
     }
 
@@ -41,7 +40,6 @@ contract BErc20 is BToken {
         underlying.safeTransferFrom(msg.sender, address(_avatar), actualRepayAmount);
         uint256 result = _avatar.repayBorrow(cToken, actualRepayAmount);
         require(result == 0, "BErc20: repayBorrow-failed");
-        updateDebtScore(msg.sender, cToken, -toInt256(repayAmount));
         return result;
     }
 }

--- a/contracts/bprotocol/btoken/BEther.sol
+++ b/contracts/bprotocol/btoken/BEther.sol
@@ -18,13 +18,11 @@ contract BEther is BToken {
 
     function mint() external payable {
         // CEther calls requireNoError() to ensure no failures
-        _iAvatarCEther().mint.value(msg.value)(cToken);
-        updateCollScore(msg.sender, cToken, toInt256(msg.value));
+        _iAvatarCEther().mint.value(msg.value)();
     }
 
     function repayBorrow() external payable {
         // CEther calls requireNoError() to ensure no failures
         _iAvatarCEther().repayBorrow.value(msg.value)();
-        updateDebtScore(msg.sender, cToken, -toInt256(msg.value));
     }
 }

--- a/contracts/bprotocol/interfaces/IAvatar.sol
+++ b/contracts/bprotocol/interfaces/IAvatar.sol
@@ -22,7 +22,7 @@ contract IAvatar is IERC20 {
 // Workaround for issue https://github.com/ethereum/solidity/issues/526
 // CEther
 contract IAvatarCEther is IAvatar {
-    function mint(address cEther) external payable;
+    function mint() external payable;
     function repayBorrow() external payable;
     function repayBorrowBehalf(address borrower) external payable;
 }

--- a/contracts/bprotocol/interfaces/IRegistry.sol
+++ b/contracts/bprotocol/interfaces/IRegistry.sol
@@ -3,8 +3,8 @@ pragma solidity 0.5.16;
 
 interface IRegistry {
 
-    function cEther() external returns (address);
-
+    function cEther() external view returns (address);
+    function score() external view returns (address);
     function avatars(address user) external view returns (address);
     function isAvatarExist(address avatar) external view returns (bool);
     function isAvatarExistFor(address user) external view returns (bool);

--- a/contracts/bprotocol/interfaces/IScore.sol
+++ b/contracts/bprotocol/interfaces/IScore.sol
@@ -1,0 +1,7 @@
+pragma solidity 0.5.16;
+
+interface IScore {
+    function updateDebtScore(address _user, address cToken, int256 amount) external;
+    function updateCollScore(address _user, address cToken, int256 amount) external;
+    function slashedScore(address _user, address cToken, int256 amount) external;
+}

--- a/contracts/bprotocol/scoring/BTokenScore.sol
+++ b/contracts/bprotocol/scoring/BTokenScore.sol
@@ -14,7 +14,8 @@ contract BTokenScore is ScoringMachine {
         _;
     }
 
-    constructor(address _registry) public {
+    function setRegistry(address _registry) public onlyOwner {
+        require(address(registry) == address(0), "Score: registry-already-set");
         registry = IRegistry(_registry);
     }
 

--- a/test-utils/BProtocolEngine.ts
+++ b/test-utils/BProtocolEngine.ts
@@ -34,6 +34,7 @@ export class BProtocol {
     public registry!: t.RegistryInstance;
     public bTokens: Map<string, t.BTokenInstance> = new Map();
     public jar!: string;
+    public score!: string;
 
     // variable to hold all Compound contracts
     public compound!: Compound;
@@ -66,6 +67,7 @@ export class BProtocolEngine {
         // Use 9th account as Pool
         _bProtocol.pool = this.accounts[9];
         _bProtocol.jar = this.accounts[8]; // TODO
+        _bProtocol.score = this.accounts[7]; // TODO
         _bProtocol.bComptroller = await this.deployBComptroller();
         _bProtocol.registry = await this.deployRegistry();
 
@@ -102,7 +104,8 @@ export class BProtocolEngine {
         const priceOracle = this.compoundUtil.getPriceOracle();
         const pool = this.bProtocol.pool;
         const bComptroller = this.bProtocol.bComptroller.address;
-        return await Registry.new(comptroller, comp, cETH, priceOracle, pool, bComptroller);
+        const bScore = this.bProtocol.score;
+        return await Registry.new(comptroller, comp, cETH, priceOracle, pool, bComptroller, bScore);
     }
 
     public getBProtocol(): BProtocol {


### PR DESCRIPTION
- [x] move scoring completely out of Avatar
- [x] Only avatar can update scores on the score contract
- [x] Avatar reads the score contract address from the registry
- [x] Fix tests

Fix for #16 