### PR TITLE
separated `liquidateBorrow()` function and Pool calls it via bToken

### DIFF
--- a/contracts/bprotocol/BComptroller.sol
+++ b/contracts/bprotocol/BComptroller.sol
@@ -32,9 +32,9 @@ contract BComptroller {
         bool is_cETH = cToken == registry.cEther();
         address bToken;
         if(is_cETH) {
-            bToken = address(new BEther(address(registry), cToken, registry.pool()));
+            bToken = address(new BEther(address(registry), cToken));
         } else {
-            bToken = address(new BErc20(address(registry), cToken, registry.pool()));
+            bToken = address(new BErc20(address(registry), cToken));
         }
 
         c2b[cToken] = bToken;

--- a/contracts/bprotocol/BComptroller.sol
+++ b/contracts/bprotocol/BComptroller.sol
@@ -8,7 +8,6 @@ import { IAvatar } from "./interfaces/IAvatar.sol";
 contract BComptroller {
 
     IRegistry public registry;
-    address public pool;
 
     // CToken => BToken
     mapping(address => address) public c2b;
@@ -17,10 +16,6 @@ contract BComptroller {
     mapping(address => address) public b2c;
 
     event NewBToken(address indexed cToken, address bToken);
-
-    constructor(address _pool) public {
-        pool = _pool;
-    }
 
     /**
      * @dev Registry address set only one time
@@ -37,9 +32,9 @@ contract BComptroller {
         bool is_cETH = cToken == registry.cEther();
         address bToken;
         if(is_cETH) {
-            bToken = address(new BEther(address(registry), cToken, pool));
+            bToken = address(new BEther(address(registry), cToken, registry.pool()));
         } else {
-            bToken = address(new BErc20(address(registry), cToken, pool));
+            bToken = address(new BErc20(address(registry), cToken, registry.pool()));
         }
 
         c2b[cToken] = bToken;

--- a/contracts/bprotocol/Pool.sol
+++ b/contracts/bprotocol/Pool.sol
@@ -216,10 +216,10 @@ contract Pool is Exponential, Ownable {
         require(err == 0, "Pool: error-in-liquidateCalculateSeizeTokens");
 
         if(_isCEther(cTokenDebt)) {
-            // TODO `amtToRepayOnCompound` sent in ETH, but splitted at `AbsCToken._liquidateBorrow()`
-            // TODO need to ensure that only needed ETH should be sent to bToken -> Avatar
-            // TODO `splitAmountToLiquidate` should calculate `underlyingAmtToLiquidate`
-            ICEther(bToken).liquidateBorrow.value(amtToRepayOnCompound)(borrower, cTokenCollateral);
+            // sending `underlyingAmtToLiquidate` ETH to Avatar
+            // Avatar will split into `amtToRepayOnCompound` and `amtToDeductFromTopup`
+            // Avatar will send back `amtToDeductFromTopup` ETH back to Pool contract
+            ICEther(bToken).liquidateBorrow.value(underlyingAmtToLiquidate)(borrower, cTokenCollateral);
         } else {
             console.log("Pool.liquidateBorrow(): avatar: %s", avatar);
             console.log("Pool.liquidateBorrow(): amtToRepayOnCompound: %s", amtToRepayOnCompound);

--- a/contracts/bprotocol/Registry.sol
+++ b/contracts/bprotocol/Registry.sol
@@ -17,6 +17,7 @@ contract Registry {
     address public pool;
     address public bComptroller;
     address public score;
+    address public jar;
 
     // User => Avatar
     mapping (address => address) public u2a;
@@ -33,7 +34,8 @@ contract Registry {
         address _priceOracle,
         address _pool,
         address _bComptroller,
-        address _score
+        address _score,
+        address _jar
     )
         public
     {
@@ -44,6 +46,7 @@ contract Registry {
         pool = _pool;
         bComptroller = _bComptroller;
         score = _score;
+        jar = _jar;
     }
 
     function newAvatar() external returns (address) {

--- a/contracts/bprotocol/avatar/AbsCToken.sol
+++ b/contracts/bprotocol/avatar/AbsCToken.sol
@@ -89,8 +89,7 @@ contract AbsCToken is Cushion {
     }
 
     function liquidateBorrow(uint256 underlyingAmtToLiquidate, ICToken cTokenCollateral) external onlyBToken returns (uint256) {
-        _liquidateBorrow(underlyingAmtToLiquidate, cTokenCollateral);
-        return 0;
+        return _liquidateBorrow(underlyingAmtToLiquidate, cTokenCollateral);
     }
 
     // CEther / CErc20
@@ -106,6 +105,7 @@ contract AbsCToken is Cushion {
         IScore score = _score();
         score.updateCollScore(address(this), address(cTokenDebt), -toInt256(underlyingSeizedTokens));
         score.updateDebtScore(address(this), address(cTokenCollateral), -toInt256(underlyingAmtToLiquidate));
+        return 0;
     }
 
     function redeem(ICToken cToken, uint256 redeemTokens) external onlyBToken postPoolOp(true) returns (uint256) {

--- a/contracts/bprotocol/avatar/Cushion.sol
+++ b/contracts/bprotocol/avatar/Cushion.sol
@@ -126,6 +126,8 @@ contract Cushion is AvatarBase {
         // 1. Is toppedUp OR partially liquidated
         bool isPartiallyLiquidated = isPartiallyLiquidated();
         require(isToppedUp() || isPartiallyLiquidated, "cannot-perform-liquidateBorrow");
+        // TODO below condition means debtCToken always = to toppedUpCToken
+        // TODO if this is true, then dont need below if-else block
         if(isPartiallyLiquidated) {
             require(debtCToken == liquidationCToken, "debtCToken-not-equal-to-liquidationCToken");
         } else {
@@ -151,7 +153,7 @@ contract Cushion is AvatarBase {
                 cETH.repayBorrow.value(amtToRepayOnCompound)();
             } else {
                 // CErc20
-                toppedUpCToken.underlying().safeTransferFrom(msg.sender, address(this), amtToRepayOnCompound);
+                toppedUpCToken.underlying().safeTransferFrom(pool, address(this), amtToRepayOnCompound);
                 require(ICErc20(address(debtCToken)).repayBorrow(amtToRepayOnCompound) == 0, "liquidateBorrow:-repayBorrow-failed");
             }
         }

--- a/contracts/bprotocol/avatar/Cushion.sol
+++ b/contracts/bprotocol/avatar/Cushion.sol
@@ -153,6 +153,8 @@ contract Cushion is AvatarBase {
                 cETH.repayBorrow.value(amtToRepayOnCompound)();
             } else {
                 // CErc20
+                console.log("in CErc20: amtToRepayOnCompound %s", amtToRepayOnCompound);
+                // take tokens from pool contract
                 toppedUpCToken.underlying().safeTransferFrom(pool, address(this), amtToRepayOnCompound);
                 require(ICErc20(address(debtCToken)).repayBorrow(amtToRepayOnCompound) == 0, "liquidateBorrow:-repayBorrow-failed");
             }
@@ -192,19 +194,26 @@ contract Cushion is AvatarBase {
     )
         public view returns (uint256 amtToDeductFromTopup, uint256 amtToRepayOnCompound)
     {
+        console.log("underlyingAmtToLiquidate: %s", underlyingAmtToLiquidate);
+        console.log("maxLiquidationAmount: %s", maxLiquidationAmount);
         // underlyingAmtToLiqScalar = underlyingAmtToLiquidate * 1e18
         (MathError mErr, Exp memory result) = mulScalar(Exp({mantissa: underlyingAmtToLiquidate}), expScale);
         require(mErr == MathError.NO_ERROR, "underlyingAmtToLiqScalar failed");
         uint underlyingAmtToLiqScalar = result.mantissa;
+        console.log("underlyingAmtToLiqScalar: %s", underlyingAmtToLiqScalar);
 
         // percent = underlyingAmtToLiqScalar / maxLiquidationAmount
         uint256 percentInScale = div_(underlyingAmtToLiqScalar, maxLiquidationAmount);
+        console.log("percentInScale: %s", percentInScale);
 
         // amtToDeductFromTopup = toppedUpAmount * percentInScale / 1e18
         amtToDeductFromTopup = mulTrucate(toppedUpAmount, percentInScale);
+        console.log("toppedUpAmount: %s", toppedUpAmount);
+        console.log("amtToDeductFromTopup: %s", amtToDeductFromTopup);
 
         // amtToRepayOnCompound = underlyingAmtToLiquidate - amtToDeductFromTopup
         amtToRepayOnCompound = sub_(underlyingAmtToLiquidate, amtToDeductFromTopup);
+        console.log("amtToRepayOnCompound: %s", amtToRepayOnCompound);
     }
 
     /**
@@ -221,6 +230,8 @@ contract Cushion is AvatarBase {
         if(! isPartiallyLiquidated()) {
             amountToLiquidate = getMaxLiquidationAmount(debtCToken);
         }
+        console.log("underlyingAmtToLiquidate: %s", underlyingAmtToLiquidate);
+        console.log("amountToLiquidate: %s", amountToLiquidate);
         (amtToDeductFromTopup, amtToRepayOnCompound) = splitAmountToLiquidate(underlyingAmtToLiquidate, amountToLiquidate);
     }
 }

--- a/contracts/bprotocol/avatar/Cushion.sol
+++ b/contracts/bprotocol/avatar/Cushion.sol
@@ -151,6 +151,11 @@ contract Cushion is AvatarBase {
                 // CEther
                 require(msg.value == amtToRepayOnCompound, "insuffecient-ETH-sent");
                 cETH.repayBorrow.value(amtToRepayOnCompound)();
+                // send back rest of the amount to the Pool contract
+                if(amtToDeductFromTopup > 0 ) {
+                    bool success = pool.send(amtToDeductFromTopup); // avoid DoS attack
+                    success; // shh
+                }
             } else {
                 // CErc20
                 console.log("in CErc20: amtToRepayOnCompound %s", amtToRepayOnCompound);

--- a/contracts/bprotocol/btoken/BErc20.sol
+++ b/contracts/bprotocol/btoken/BErc20.sol
@@ -42,4 +42,11 @@ contract BErc20 is BToken {
         require(result == 0, "BErc20: repayBorrow-failed");
         return result;
     }
+
+    function liquidateBorrow(address borrower, uint repayAmount, address cTokenCollateral) external onlyPool returns (uint) {
+        address borrowerAvatar = registry.avatarOf(borrower);
+        uint result = IAvatarCErc20(borrowerAvatar).liquidateBorrow(repayAmount, cTokenCollateral);
+        require(result == 0, "BErc20: liquidateBorrow-failed");
+        return result;
+    }
 }

--- a/contracts/bprotocol/btoken/BErc20.sol
+++ b/contracts/bprotocol/btoken/BErc20.sol
@@ -13,9 +13,8 @@ contract BErc20 is BToken {
 
     constructor(
         address _registry,
-        address _cToken,
-        address _pool
-    ) public BToken(_registry, _cToken, _pool) {
+        address _cToken
+    ) public BToken(_registry, _cToken) {
         underlying = ICToken(cToken).underlying();
     }
 

--- a/contracts/bprotocol/btoken/BEther.sol
+++ b/contracts/bprotocol/btoken/BEther.sol
@@ -8,9 +8,8 @@ contract BEther is BToken {
 
     constructor(
         address _registry,
-        address _cToken,
-        address _pool
-    ) public BToken(_registry, _cToken, _pool) {}
+        address _cToken
+    ) public BToken(_registry, _cToken) {}
 
     function _iAvatarCEther() internal returns (IAvatarCEther) {
         return IAvatarCEther(address(avatar()));

--- a/contracts/bprotocol/btoken/BEther.sol
+++ b/contracts/bprotocol/btoken/BEther.sol
@@ -25,4 +25,9 @@ contract BEther is BToken {
         // CEther calls requireNoError() to ensure no failures
         _iAvatarCEther().repayBorrow.value(msg.value)();
     }
+
+    function liquidateBorrow(address borrower, address cTokenCollateral) external payable onlyPool {
+        address borrowerAvatar = registry.avatarOf(borrower);
+        IAvatarCEther(borrowerAvatar).liquidateBorrow.value(msg.value)(cTokenCollateral);
+    }
 }

--- a/contracts/bprotocol/btoken/BToken.sol
+++ b/contracts/bprotocol/btoken/BToken.sol
@@ -20,18 +20,15 @@ contract BToken is Exponential {
     IRegistry public registry;
     // Compound's CToken this BToken contract is tied to
     address public cToken;
-    // Pool contract
-    address public pool;
 
     modifier onlyPool() {
-        require(msg.sender == pool, "BToken: only-pool-is-authorized");
+        require(msg.sender == registry.pool(), "BToken: only-pool-is-authorized");
         _;
     }
 
-    constructor(address _registry, address _cToken, address _pool) internal {
+    constructor(address _registry, address _cToken) internal {
         registry = IRegistry(_registry);
         cToken = _cToken;
-        pool = _pool;
     }
 
     function avatar() public returns (IAvatar) {

--- a/contracts/bprotocol/btoken/BToken.sol
+++ b/contracts/bprotocol/btoken/BToken.sol
@@ -23,6 +23,11 @@ contract BToken is Exponential {
     // Pool contract
     address public pool;
 
+    modifier onlyPool() {
+        require(msg.sender == pool, "BToken: only-pool-is-authorized");
+        _;
+    }
+
     constructor(address _registry, address _cToken, address _pool) internal {
         registry = IRegistry(_registry);
         cToken = _cToken;
@@ -63,26 +68,6 @@ contract BToken is Exponential {
         return result;
     }
 
-    /**
-     * @dev Liquidate borrow an Avatar
-     * @notice Only Pool contract can call this function
-     * @param targetAvatar Avatar to liquidate
-     * @param amount Underlying amount to liquidate
-     * @param collateral Collateral CToken address
-     */
-    function liquidateBorrow(
-        address targetAvatar,
-        uint256 amount,
-        address collateral
-    )
-        external
-        payable
-    {
-        require(registry.isAvatarExist(targetAvatar), "BToken: avatar-not-exists");
-        require(msg.sender == pool, "BToken: only-pool-is-authorized");
-
-        IAvatar(targetAvatar).liquidateBorrow.value(msg.value)(cToken, amount, collateral);
-    }
 
     // IERC20
     // =======

--- a/contracts/bprotocol/interfaces/CTokenInterfaces.sol
+++ b/contracts/bprotocol/interfaces/CTokenInterfaces.sol
@@ -31,14 +31,12 @@ contract CTokenInterface {
 
 }
 
-
 contract ICToken is CTokenInterface {
 
     /*** User Interface ***/
     function redeem(uint redeemTokens) external returns (uint);
     function redeemUnderlying(uint redeemAmount) external returns (uint);
     function borrow(uint borrowAmount) external returns (uint);
-    function liquidateBorrow(address borrower, uint repayAmount, CTokenInterface cTokenCollateral) external returns (uint);
 }
 
 // Workaround for issue https://github.com/ethereum/solidity/issues/526
@@ -47,12 +45,14 @@ contract ICErc20 is ICToken {
     function mint(uint mintAmount) external returns (uint);
     function repayBorrow(uint repayAmount) external returns (uint);
     function repayBorrowBehalf(address borrower, uint repayAmount) external returns (uint);
+    function liquidateBorrow(address borrower, uint repayAmount, address cTokenCollateral) external returns (uint);
 }
 
 contract ICEther is ICToken {
     function mint() external payable;
     function repayBorrow() external payable;
     function repayBorrowBehalf(address borrower) external payable;
+    function liquidateBorrow(address borrower, address cTokenCollateral) external payable;
 }
 
 contract IPriceOracle {

--- a/contracts/bprotocol/interfaces/IAvatar.sol
+++ b/contracts/bprotocol/interfaces/IAvatar.sol
@@ -12,7 +12,6 @@ contract IAvatar is IERC20 {
     function redeem(address cToken, uint256 redeemTokens) external returns (uint256);
     function redeemUnderlying(address cToken, uint256 redeemAmount) external returns (uint256);
     function borrow(address cToken, uint256 borrowAmount) external returns (uint256);
-    function liquidateBorrow(address debtCToken, uint256 underlyingAmtToLiquidate, address collCToken) external payable returns (uint256);
     function borrowBalanceCurrent(address cToken) external returns (uint256);
 
     // Comptroller functions
@@ -25,6 +24,7 @@ contract IAvatarCEther is IAvatar {
     function mint() external payable;
     function repayBorrow() external payable;
     function repayBorrowBehalf(address borrower) external payable;
+    function liquidateBorrow(address cTokenCollateral) external payable;
 }
 
 // CErc20
@@ -32,6 +32,7 @@ contract IAvatarCErc20 is IAvatar {
     function mint(address cToken, uint256 mintAmount) external returns (uint256);
     function repayBorrow(address cToken, uint256 repayAmount) external returns (uint256);
     function repayBorrowBehalf(address cToken, address borrower, uint256 repayAmount) external returns (uint256);
+    function liquidateBorrow(uint repayAmount, address cTokenCollateral) external returns (uint256);
 }
 
 contract ICushion {

--- a/contracts/bprotocol/interfaces/IRegistry.sol
+++ b/contracts/bprotocol/interfaces/IRegistry.sol
@@ -3,8 +3,16 @@ pragma solidity 0.5.16;
 
 interface IRegistry {
 
+    // Compound contracts
+    function comptroller() external view returns (address);
     function cEther() external view returns (address);
+
+    // B.Protocol contracts
     function score() external view returns (address);
+    function pool() external view returns (address);
+    function jar() external view returns (address);
+
+    // Avatar functions
     function avatars(address user) external view returns (address);
     function isAvatarExist(address avatar) external view returns (bool);
     function isAvatarExistFor(address user) external view returns (bool);

--- a/test-utils/BProtocolEngine.ts
+++ b/test-utils/BProtocolEngine.ts
@@ -28,9 +28,8 @@ export class Compound {
 
 // BProtocol Class to store all BProtocol deployed contracts
 export class BProtocol {
-    // TODO For now fake EOA is a pool
-    public pool!: string;
-    //public pool!: t.PoolInstance;
+    public pool!: t.PoolInstance;
+    public members!: Array<string>;
     public bComptroller!: t.BComptrollerInstance;
     public registry!: t.RegistryInstance;
     public bTokens: Map<string, t.BTokenInstance> = new Map();
@@ -64,13 +63,12 @@ export class BProtocolEngine {
     public async deployBProtocol(): Promise<BProtocol> {
         this.bProtocol = new BProtocol();
         const _bProtocol = this.bProtocol;
-        //_bProtocol.pool = await this.deployPool();
-        // Use 9th account as Pool
-        _bProtocol.pool = this.accounts[9];
-        _bProtocol.jar = this.accounts[8]; // TODO
-        _bProtocol.bComptroller = await this.deployBComptroller();
+        _bProtocol.jar = this.accounts[5]; // TODO
+
         _bProtocol.score = await this.deployScore();
         _bProtocol.registry = await this.deployRegistry();
+        _bProtocol.pool = await this.deployPool();
+        _bProtocol.bComptroller = await this.deployBComptroller();
 
         await _bProtocol.score.setRegistry(_bProtocol.registry.address);
         await _bProtocol.bComptroller.setRegistry(_bProtocol.registry.address);
@@ -89,8 +87,21 @@ export class BProtocolEngine {
 
     // Deploy Pool contract
     private async deployPool(): Promise<t.PoolInstance> {
+        this.bProtocol.members.push(this.accounts[6]);
+        this.bProtocol.members.push(this.accounts[7]);
+        this.bProtocol.members.push(this.accounts[8]);
+        this.bProtocol.members.push(this.accounts[9]);
+        const comptroller = this.compoundUtil.getContracts("Comptroller");
         const cETH = this.compoundUtil.getContracts("cETH");
-        return await Pool.new(cETH, this.bProtocol.jar);
+        const pool = await Pool.new(
+            comptroller,
+            cETH,
+            this.bProtocol.registry.address,
+            this.bProtocol.jar,
+        );
+        await pool.setMembers(this.bProtocol.members);
+        await pool.setProfitParams(105, 110);
+        return pool;
     }
 
     private async deployScore(): Promise<t.BTokenScoreInstance> {
@@ -99,7 +110,7 @@ export class BProtocolEngine {
 
     // Deploy BComptroller contract
     private async deployBComptroller(): Promise<t.BComptrollerInstance> {
-        return await BComptroller.new(this.bProtocol.pool);
+        return await BComptroller.new(this.bProtocol.pool.address);
     }
 
     // Deploy Registry contract
@@ -111,7 +122,15 @@ export class BProtocolEngine {
         const pool = this.bProtocol.pool;
         const bComptroller = this.bProtocol.bComptroller.address;
         const bScore = this.bProtocol.score.address;
-        return await Registry.new(comptroller, comp, cETH, priceOracle, pool, bComptroller, bScore);
+        return await Registry.new(
+            comptroller,
+            comp,
+            cETH,
+            priceOracle,
+            pool.address,
+            bComptroller,
+            bScore,
+        );
     }
 
     public getBProtocol(): BProtocol {

--- a/test-utils/BProtocolEngine.ts
+++ b/test-utils/BProtocolEngine.ts
@@ -29,7 +29,7 @@ export class Compound {
 // BProtocol Class to store all BProtocol deployed contracts
 export class BProtocol {
     public pool!: t.PoolInstance;
-    public members!: Array<string>;
+    public members: Array<string> = new Array();
     public bComptroller!: t.BComptrollerInstance;
     public registry!: t.RegistryInstance;
     public bTokens: Map<string, t.BTokenInstance> = new Map();
@@ -66,10 +66,11 @@ export class BProtocolEngine {
         _bProtocol.jar = this.accounts[5]; // TODO
 
         _bProtocol.score = await this.deployScore();
-        _bProtocol.registry = await this.deployRegistry();
         _bProtocol.pool = await this.deployPool();
         _bProtocol.bComptroller = await this.deployBComptroller();
+        _bProtocol.registry = await this.deployRegistry();
 
+        await _bProtocol.pool.setRegistry(_bProtocol.registry.address);
         await _bProtocol.score.setRegistry(_bProtocol.registry.address);
         await _bProtocol.bComptroller.setRegistry(_bProtocol.registry.address);
 
@@ -93,12 +94,7 @@ export class BProtocolEngine {
         this.bProtocol.members.push(this.accounts[9]);
         const comptroller = this.compoundUtil.getContracts("Comptroller");
         const cETH = this.compoundUtil.getContracts("cETH");
-        const pool = await Pool.new(
-            comptroller,
-            cETH,
-            this.bProtocol.registry.address,
-            this.bProtocol.jar,
-        );
+        const pool = await Pool.new();
         await pool.setMembers(this.bProtocol.members);
         await pool.setProfitParams(105, 110);
         return pool;
@@ -110,7 +106,7 @@ export class BProtocolEngine {
 
     // Deploy BComptroller contract
     private async deployBComptroller(): Promise<t.BComptrollerInstance> {
-        return await BComptroller.new(this.bProtocol.pool.address);
+        return await BComptroller.new();
     }
 
     // Deploy Registry contract
@@ -122,6 +118,7 @@ export class BProtocolEngine {
         const pool = this.bProtocol.pool;
         const bComptroller = this.bProtocol.bComptroller.address;
         const bScore = this.bProtocol.score.address;
+        const jar = this.bProtocol.jar;
         return await Registry.new(
             comptroller,
             comp,
@@ -130,6 +127,7 @@ export class BProtocolEngine {
             pool.address,
             bComptroller,
             bScore,
+            jar,
         );
     }
 

--- a/test/integration/TestLiquidationIntegration.spec.ts
+++ b/test/integration/TestLiquidationIntegration.spec.ts
@@ -342,9 +342,9 @@ contract("Pool performs liquidation", async (accounts) => {
 
                 const toppedUpAmount = await avatarUser1.toppedUpAmount();
 
-                const result = await avatarUser1.splitAmountToLiquidate(
+                const result = await avatarUser1.calcAmountToLiquidate.call(
+                    cZRX_addr,
                     tokensToLiquidate,
-                    maxLiquidationAmount,
                 );
                 const amtToRepayOnCompound = result[1];
 
@@ -357,14 +357,7 @@ contract("Pool performs liquidation", async (accounts) => {
                 await pool.methods["deposit(address,uint256)"](ZRX.address, amtToRepayOnCompound, {
                     from: member1,
                 });
-                /*
-                let amtToDeductFromTopup;
-                let amtToRepayOnCompound;
-                [
-                    amtToDeductFromTopup,
-                    amtToRepayOnCompound,
-                ] = await avatarUser1.calcAmountToLiquidate.call(cETH_addr, tokensToLiquidate);
-                */
+
                 const resetApprove: boolean = (
                     await ZRX.allowance(pool.address, avatarUser1.address)
                 ).gt(new BN(0));


### PR DESCRIPTION
- [x] Fix linking between Member -> Pool -> BToken -> Avatar -> Compound
- [x] Think how to fix ETH (as amoutToLiquidate) sent from Pool -> BToken -> Avatar. We might need to calculate `amtToSendOnCompound` differently for ETH case. (Solution: No better solution found as we wanted to keep the BToken interface just like CToken. Hence, cannot pass `underlyingAmtToLiquidate` / `amtToDedctFromTopup`. Due to this we cannot calculate only with `amtToRepayOnCompound`. So the simple solution is to return the `amtToDedctFromTopup` ETH from Avatar to the Pool contract)
- [x] Fix circular dependencies Registry, Pool, BComptroller contracts.
- [x] Fix tests