### PR TITLE
Reuse deployed compound contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,7 @@ Run Hardhat EVM (in separate shell window):
 
     npx hardhat node
 
-Deploy Compound Contracts on ganache. Below command requires `solc` command installed, if not installed run `sudo snap install solc` (only for ubuntu). The `solc` version should be `0.5.16`. You can use `solc-select` (https://github.com/crytic/solc-select):
-
-    npm run deploy-compound
-
-Execute tests:
+The tests automaticallt deploys Compound Contracts on ganache / hardhat-HRE. Below command requires `solc` command installed, if not installed, run `sudo snap install solc` (only for ubuntu). The `solc` version should be `0.5.16`. You can use `solc-select` (https://github.com/crytic/solc-select):
 
     npx hardhat test
 

--- a/test-utils/BProtocolEngine.ts
+++ b/test-utils/BProtocolEngine.ts
@@ -1,5 +1,4 @@
 import * as b from "../types/index";
-import fs, { exists } from "fs";
 
 import { CompoundUtils } from "./CompoundUtils";
 import { takeSnapshot, revertToSnapShot } from "../test-utils/SnapshotUtils";

--- a/test-utils/BProtocolEngine.ts
+++ b/test-utils/BProtocolEngine.ts
@@ -54,6 +54,11 @@ export class BProtocolEngine {
 
   // Deploy Compound contracts
   public async deployCompound() {
+    const code = await web3.eth.getCode(this.compoundUtil.getComptroller());
+    const isDeployed = code !== "0x";
+
+    if (isDeployed) return;
+
     const deployCommand = "npm run deploy-compound";
 
     console.log("Executing command:" + deployCommand);


### PR DESCRIPTION
- [x] Reuse compound deployment
- [x] Dont need `npm run deploy-compound` to run `npx hardhat test`